### PR TITLE
Some more ways to use Perl in Github Actions.

### DIFF
--- a/.github/workflows/linux-vendor-cpanm.yml
+++ b/.github/workflows/linux-vendor-cpanm.yml
@@ -1,0 +1,15 @@
+name: linux-vendor-cpanm
+on: push
+jobs:
+  perl:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: perl -V
+      run: perl -V
+    - name: Install cpanm
+      run: curl -L http://cpanmin.us | perl - --sudo App::cpanminus
+    - name: Install Dependencies
+      run: cpanm --installdeps .
+    #- name: Run Tests
+    #  run: prove -l t

--- a/.github/workflows/linux-vendor.yml
+++ b/.github/workflows/linux-vendor.yml
@@ -1,0 +1,13 @@
+name: linux-vendor
+on: push
+jobs:
+  perl:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: perl -V
+      run: perl -V
+    - name: Install Dependencies
+      run: curl -sL https://git.io/cpm | perl - install --show-build-log-on-failure --cpanfile=cpanfile
+    #- name: Run Tests
+    #  run: prove -l t

--- a/.github/workflows/linux-with-perl-setup.yml
+++ b/.github/workflows/linux-with-perl-setup.yml
@@ -1,0 +1,17 @@
+name: linux-with-perl-setup
+on: push
+jobs:
+  perl:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup Perl
+      uses: shogo82148/actions-setup-perl@v1
+      with:
+        perl-version: '5.30'
+    - name: perl -V
+      run: perl -V
+    - name: Install Dependencies
+      run: curl -sL https://git.io/cpm | perl - install --global --show-build-log-on-failure --cpanfile=cpanfile
+    - name: Run Tests
+      run: prove -l t


### PR DESCRIPTION
Hello,

I propose to add some more examples on how to use Github Actions for Perl projects.
One example uses perl vendor which is probably not recommended but can do the job.
One example uses cpanm instead cpm.
One example uses https://github.com/shogo82148/actions-setup-perl to setup Perl (we can improve with matrix)

I disabled the prove -l t on vendor's examples because there is an "obscure" (for me) issue with Plack::Test module (with both cpm and cpanm). Maybe you can find why (it would be great) but I just disabled it for now.

I hope this PR will fit your quality criteria so we can enrich your repository to have more examples about Github Actions and Perl for the Perl folks.